### PR TITLE
feat: Add `get_model` to get a specific model more programablly

### DIFF
--- a/lightdash/client.py
+++ b/lightdash/client.py
@@ -158,4 +158,15 @@ class Client:
             LightdashError: If the API returns an error response
             httpx.HTTPError: If there's a network or HTTP protocol error
         """
-        return self.models.list() 
+        return self.models.list()
+
+    def get_model(self, name: str) -> Model:
+        """Get a model by name.
+
+        Args:
+            name: The name of the model to get
+
+        Returns:
+            A Model object representing the requested explore
+        """
+        return self.models.get(name)

--- a/lightdash/models.py
+++ b/lightdash/models.py
@@ -156,4 +156,11 @@ class Models:
     def list(self) -> List[Model]:
         """List all available models."""
         self._ensure_loaded()
-        return list(self._models.values()) 
+        return list(self._models.values())
+
+    def get_model(self, name: str) -> Model:
+        """Get a model by name, fetching from API if needed."""
+        self._ensure_loaded()
+        if self._models is None or name not in self._models:
+            raise ValueError(f"No model named '{name}' found")
+        return self._models[name]

--- a/lightdash/models.py
+++ b/lightdash/models.py
@@ -142,11 +142,7 @@ class Models:
 
     def __getattr__(self, name: str) -> Model:
         """Get a model by name, fetching from API if needed."""
-        self._ensure_loaded()
-        try:
-            return self._models[name]
-        except KeyError:
-            raise AttributeError(f"No model named '{name}' found")
+        return self.get(name)
 
     def __dir__(self) -> List[str]:
         """Enable tab completion by returning list of model names."""
@@ -158,9 +154,10 @@ class Models:
         self._ensure_loaded()
         return list(self._models.values())
 
-    def get_model(self, name: str) -> Model:
+    def get(self, name: str) -> Model:
         """Get a model by name, fetching from API if needed."""
         self._ensure_loaded()
-        if self._models is None or name not in self._models:
-            raise ValueError(f"No model named '{name}' found")
-        return self._models[name]
+        try:
+            return self._models[name]
+        except KeyError:
+            raise AttributeError(f"No model named '{name}' found")


### PR DESCRIPTION
## Overview
We can already access a model as an attribute of the `Models` class like `client.models.orders`. It would be great to get a model by the name. By doing so, we can access models more prgramablly.

```python
model = client.models.get_model("orders")
model.list_dimensions()
model.list_metrics()
```