### PR TITLE
fix: errored models breaking `list_models` method

### DIFF
--- a/lightdash/models.py
+++ b/lightdash/models.py
@@ -108,13 +108,16 @@ class Model:
     @classmethod
     def from_api_response(cls, data: Dict[str, Any]) -> "Model":
         """Create a Model instance from API response data."""
+        if "errors" in data:
+            print(f"Model has errors: {data['name']}")
+
         return cls(
             name=data["name"],
-            type=data["type"],
-            database_name=data["databaseName"],
-            schema_name=data["schemaName"],
-            label=data.get("label"),
-            description=data.get("description"),
+            type=data.get("type", "error" if "errors" in data else "default"),
+            database_name=data.get("databaseName", None),
+            schema_name=data.get("schemaName", None),
+            label=data.get("label", None),
+            description=data.get("description", None),
         )
 
 

--- a/lightdash/types.py
+++ b/lightdash/types.py
@@ -23,8 +23,8 @@ class Model(Protocol):
     """Type protocol for a Lightdash model."""
     name: str
     type: str
-    database_name: str
-    schema_name: str
+    database_name: Optional[str]
+    schema_name: Optional[str]
     label: Optional[str]
     description: Optional[str]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -864,11 +865,10 @@ wheels = [
 
 [[package]]
 name = "lightdash"
-version = "0.2.3"
+version = "0.2.4"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx" },
-    { name = "polars" },
 ]
 
 [package.optional-dependencies]
@@ -876,6 +876,7 @@ dev = [
     { name = "ipykernel" },
     { name = "jupyter" },
     { name = "pandas" },
+    { name = "polars" },
     { name = "pytest" },
 ]
 
@@ -885,9 +886,10 @@ requires-dist = [
     { name = "ipykernel", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pandas", marker = "extra == 'dev'", specifier = ">=2.0.0" },
-    { name = "polars", specifier = ">=1.22.0" },
+    { name = "polars", marker = "extra == 'dev'", specifier = ">=1.22.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "markupsafe"


### PR DESCRIPTION
Fixes issue when some of the models returned from API contain `errors` field:

```json
    {
      "name": "normal_model",
      "label": "Model label",
      "tags": ["staging", "nightly"],
      "databaseName": "lightdash-test",
      "schemaName": "staging",
      "description": "description",
      "type": "default"
    },
    {
      "name": "errored_model",
      "label": "label",
      "errors": [
        { "type": "NO_DIMENSIONS_FOUND", "message": "No dimensions available" }
      ]
    },
```

It was failing with this error:

```py
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[5], line 6, in fetch_lightdash_semantic_layer()
      5 try:
----> 6     models = client.list_models()
      7     if not models:

File ~/anaconda3/lib/python3.11/site-packages/lightdash/client.py:161, in Client.list_models(self)
    151 """
    152 List all available models (explores) in the project.
    153 
   (...)
    159     httpx.HTTPError: If there's a network or HTTP protocol error
    160 """
--> 161 return self.models.list()

File ~/anaconda3/lib/python3.11/site-packages/lightdash/models.py:157, in Models.list(self)
    156 """List all available models."""
--> 157 self._ensure_loaded()
    158 return list(self._models.values())

File ~/anaconda3/lib/python3.11/site-packages/lightdash/models.py:136, in Models._ensure_loaded(self)
    135 if self._models is None:
--> 136     models = self._client._fetch_models()
    137     self._models = {model.name: model for model in models}

File ~/anaconda3/lib/python3.11/site-packages/lightdash/client.py:148, in Client._fetch_models(self)
    147 response_data = self._make_request("GET", path)
--> 148 return [Model.from_api_response(item) for item in response_data]

File ~/anaconda3/lib/python3.11/site-packages/lightdash/client.py:148, in <listcomp>(.0)
    147 response_data = self._make_request("GET", path)
--> 148 return [Model.from_api_response(item) for item in response_data]

File ~/anaconda3/lib/python3.11/site-packages/lightdash/models.py:112, in Model.from_api_response(cls, data)
    109 """Create a Model instance from API response data."""
    110 return cls(
    111     name=data["name"],
--> 112     type=data["type"],
    113     database_name=data["databaseName"],
    114     schema_name=data["schemaName"],
    115     label=data.get("label"),
    116     description=data.get("description"),
    117 )

KeyError: 'type'
```


Thread: https://lightdash.slack.com/archives/C04KD95TF0U/p1743448606746949
