### PR TITLE
docs: add between() and not_between() to SDK guide

### DIFF
--- a/docs/SDK_GUIDE.md
+++ b/docs/SDK_GUIDE.md
@@ -116,6 +116,10 @@ f = model.dimensions.name.includes("Smith")
 # Null checks
 f = model.dimensions.email.is_null()
 f = model.dimensions.email.is_not_null()
+
+# Range checks
+f = model.dimensions.order_date.between("2024-01-01", "2024-12-31")
+f = model.dimensions.amount.not_between(100, 500)
 ```
 
 ### Supported Operators by Data Type
@@ -136,7 +140,8 @@ f = model.dimensions.email.is_not_null()
 | `in the current` | - | - | - | Yes |
 | `is before` | - | - | - | Yes |
 | `is after` | - | - | - | Yes |
-| `is between` | - | - | - | Yes |
+| `is between` | Yes | - | - | Yes |
+| `is not between` | Yes | - | - | Yes |
 
 ### Combining Filters
 


### PR DESCRIPTION
## Changes

Updated SDK_GUIDE.md documentation to include examples and operator support information for `between()` and `not_between()` filter methods.

### Details
- Added code examples showing usage of `between()` and `not_between()` operators
- Updated the operator compatibility table to reflect support for these methods on numeric data types
- Marked `between` and `not_between` as supported for numeric fields in the operator matrix