### PR TITLE
feat: support multiple filters on the same dimension field

### DIFF
--- a/docs/SDK_GUIDE.md
+++ b/docs/SDK_GUIDE.md
@@ -171,6 +171,28 @@ query = (
 )
 ```
 
+### Multiple Filters on the Same Field
+
+You can apply more than one condition to the same field—for example, to constrain
+a date dimension to a range:
+
+```python
+query = model.query().filter(
+    (model.dimensions.order_date >= "2026-01-01") &
+    (model.dimensions.order_date <= "2026-01-31")
+)
+```
+
+The same works across separate `.filter()` calls, since they are AND-ed together:
+
+```python
+query = (
+    model.query()
+    .filter(model.dimensions.order_date >= "2026-01-01")
+    .filter(model.dimensions.order_date <= "2026-01-31")
+)
+```
+
 ---
 
 ## Dimensions and Metrics

--- a/lightdash/filter.py
+++ b/lightdash/filter.py
@@ -118,17 +118,12 @@ class CompositeFilter:
 
     def to_dict(self):
         out = []
-        processed_field_ids = set()
         for f in self.filters:
             # Check that the filter is not a composite filter
             if not hasattr(f, "field"):
                 raise TypeError("Multi-level filter composites not supported yet")
-            # Check that we have at most one filter per field
-            if f.field.field_id in processed_field_ids:
-                raise NotImplementedError(
-                    f"Multiple filters for field {f.field.field_id} not implemented yet"
-                )
-            processed_field_ids.add(f.field.field_id)
+            # Multiple filters may target the same field, e.g. a date range
+            # expressed as (dim >= start) & (dim <= end).
             out.append(f.to_dict())
         return {"dimensions": {self.aggregation: out}}
 

--- a/tests/test_filter_operators.py
+++ b/tests/test_filter_operators.py
@@ -214,6 +214,56 @@ class TestFilterCombining:
         assert len(result.filters) == 3
 
 
+class TestSameFieldFilters:
+    """Test multiple filters on the same field (issue #20)."""
+
+    def test_range_filter_on_same_field(self, dimension):
+        """Test (dim >= x) & (dim <= y) serializes both rules."""
+        composite = (dimension >= "2026-01-01") & (dimension <= "2026-01-31")
+        result = composite.to_dict()
+        rules = result["dimensions"]["and"]
+        assert len(rules) == 2
+        assert rules[0]["target"]["fieldId"] == "test_model_country"
+        assert rules[0]["operator"] == "greaterThanOrEqual"
+        assert rules[0]["values"] == ["2026-01-01"]
+        assert rules[1]["target"]["fieldId"] == "test_model_country"
+        assert rules[1]["operator"] == "lessThanOrEqual"
+        assert rules[1]["values"] == ["2026-01-31"]
+
+    def test_or_filters_on_same_field(self, dimension):
+        """Test (dim == a) | (dim == b) serializes both rules."""
+        composite = (dimension == "USA") | (dimension == "UK")
+        rules = composite.to_dict()["dimensions"]["or"]
+        assert len(rules) == 2
+        assert all(r["target"]["fieldId"] == "test_model_country" for r in rules)
+
+    def test_three_filters_on_same_field(self, dimension2):
+        """Test chaining more than two filters on the same field."""
+        composite = (dimension2 > 0) & (dimension2 < 100) & (dimension2 != 50)
+        rules = composite.to_dict()["dimensions"]["and"]
+        assert len(rules) == 3
+
+    def test_same_field_via_query_filter_chain(self):
+        """Two .filter() calls on the same field are both serialized."""
+        from lightdash.models import Model
+
+        model = Model(
+            name="test_model", type="default",
+            database_name="db", schema_name="s",
+        )
+        order_date = Dimension(name="order_date", model_name="test_model")
+        query = (
+            model.query()
+            .filter(order_date >= "2026-01-01")
+            .filter(order_date <= "2026-01-31")
+        )
+        rules = query._build_payload()["filters"]["dimensions"]["and"]
+        assert len(rules) == 2
+        assert {r["operator"] for r in rules} == {
+            "greaterThanOrEqual", "lessThanOrEqual"
+        }
+
+
 class TestBackwardsCompatibility:
     """Test that original filter constructors still work."""
 


### PR DESCRIPTION
Closes #20

## Problem

Applying more than one filter to the same field — e.g. constraining a date dimension to a range — raised:

```
NotImplementedError: Multiple filters for field <field_name> not implemented yet
```

```python
.filter(
    (model.dimensions.datetime_day >= date_x) &
    (model.dimensions.datetime_day <= date_y)
)
```

## Change

Removes the self-imposed `processed_field_ids` guard in `CompositeFilter.to_dict()`. That check was a placeholder ("not implemented yet"), not an API constraint — the Lightdash API accepts multiple rules per field, using the **same `{target, operator, values}` shape already used for single dimension filters**. We simply emit one entry per rule under `filters.dimensions`.

A date range now serializes as:

```json
{"dimensions": {"and": [
  {"target": {"fieldId": "orders_datetime_day"}, "operator": "greaterThanOrEqual", "values": ["2026-01-01"]},
  {"target": {"fieldId": "orders_datetime_day"}, "operator": "lessThanOrEqual",    "values": ["2026-01-31"]}
]}}
```

## Tests

Adds `TestSameFieldFilters` covering same-field AND/OR combinations, 3+ rules on one field, and the `.filter().filter()` chain path. All 54 filter/query-builder unit tests pass.

## Scope

This is the first of three related issues (#19 row limit, #21 table-calculation filters) — split out on its own because it's a low-risk, self-contained removal of a client-side guard. #19 and #21 will follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)