### PR TITLE
fix: clear errors for connection, auth, and API failures

### DIFF
--- a/lightdash/__init__.py
+++ b/lightdash/__init__.py
@@ -6,6 +6,8 @@ A Python client for interacting with the Lightdash API.
 from lightdash.client import Client
 from lightdash.exceptions import (
     LightdashError,
+    LightdashConnectionError,
+    LightdashAuthError,
     QueryError,
     QueryTimeout,
     QueryCancelled,
@@ -20,6 +22,8 @@ from lightdash.results import ResultSet, BaseResult
 __all__ = [
     'Client',
     'LightdashError',
+    'LightdashConnectionError',
+    'LightdashAuthError',
     'QueryError',
     'QueryTimeout',
     'QueryCancelled',

--- a/lightdash/client.py
+++ b/lightdash/client.py
@@ -9,7 +9,11 @@ import logging
 from urllib.parse import urljoin
 
 from .models import Model, Models
-from .exceptions import LightdashError
+from .exceptions import (
+    LightdashError,
+    LightdashConnectionError,
+    LightdashAuthError,
+)
 from .sql_runner import SqlRunner, SqlResult
 
 
@@ -94,15 +98,39 @@ class Client:
             },
             timeout=self.timeout
         ) as client:
-            response = client.request(
-                method=method,
-                url=url,
-                params=params,
-                json=json,
-            )
-            
+            try:
+                response = client.request(
+                    method=method,
+                    url=url,
+                    params=params,
+                    json=json,
+                )
+            except httpx.TimeoutException as e:
+                raise LightdashConnectionError(
+                    f"Request to {self.instance_url} timed out after {self.timeout}s. "
+                    "The instance may be unreachable or overloaded."
+                ) from e
+            except httpx.ConnectError as e:
+                raise LightdashConnectionError(
+                    f"Could not connect to Lightdash at {self.instance_url}. "
+                    "Check that instance_url is correct and the instance is reachable."
+                ) from e
+            except httpx.RequestError as e:
+                raise LightdashConnectionError(
+                    f"Network error connecting to Lightdash at {self.instance_url}: {e}"
+                ) from e
+
             self._log_response(response)
-            
+
+            # Authentication failures get a dedicated, actionable message.
+            if response.status_code in (401, 403):
+                raise LightdashAuthError(
+                    f"Authentication failed (HTTP {response.status_code}) for "
+                    f"{self.instance_url}. Check that your access_token is valid and "
+                    "has access to this project.",
+                    status_code=response.status_code,
+                )
+
             # Raise HTTP errors
             try:
                 response.raise_for_status()

--- a/lightdash/exceptions.py
+++ b/lightdash/exceptions.py
@@ -10,6 +10,26 @@ class LightdashError(Exception):
         super().__init__(f"{name} ({status_code}): {message}")
 
 
+class LightdashConnectionError(LightdashError):
+    """Raised when the SDK cannot reach the Lightdash instance.
+
+    Covers DNS failures, refused connections, and timeouts — typically an
+    incorrect ``instance_url`` or an instance that is down or unreachable.
+    """
+    def __init__(self, message: str):
+        super().__init__(message, "LightdashConnectionError", 0)
+
+
+class LightdashAuthError(LightdashError):
+    """Raised when authentication fails (HTTP 401/403).
+
+    Typically an invalid or expired ``access_token``, or a token without
+    access to the requested project.
+    """
+    def __init__(self, message: str, status_code: int = 401):
+        super().__init__(message, "LightdashAuthError", status_code)
+
+
 class QueryError(LightdashError):
     """Raised when a query fails."""
     def __init__(self, message: str, query_uuid: str = None):

--- a/tests/test_client_errors.py
+++ b/tests/test_client_errors.py
@@ -1,0 +1,101 @@
+"""
+Tests for clear connection / auth error messages (issue #1).
+
+A misconfigured client used to surface a raw ``httpx`` error that never
+mentioned Lightdash. These tests verify the SDK now translates the two reported
+cases — unreachable instance and bad credentials — into descriptive exceptions,
+while leaving the existing API-error handling untouched.
+"""
+
+import httpx
+import pytest
+from lightdash import (
+    Client,
+    LightdashError,
+    LightdashConnectionError,
+    LightdashAuthError,
+)
+
+
+def _client() -> Client:
+    return Client(
+        instance_url="https://demo.lightdash.cloud",
+        access_token="ldpat_token",
+        project_uuid="proj",
+    )
+
+
+def _response(status: int, json_body=None, text: str = "") -> httpx.Response:
+    request = httpx.Request("GET", "https://demo.lightdash.cloud/api/v1/x")
+    if json_body is not None:
+        return httpx.Response(status, json=json_body, request=request)
+    return httpx.Response(status, text=text, request=request)
+
+
+class TestConnectionErrors:
+    def test_connect_error_is_wrapped(self, monkeypatch):
+        """A DNS/connection failure names the instance and the likely cause."""
+        def boom(*args, **kwargs):
+            raise httpx.ConnectError("nodename nor servname provided, or not known")
+        monkeypatch.setattr(httpx.Client, "request", boom)
+
+        with pytest.raises(LightdashConnectionError, match="Could not connect to Lightdash") as ei:
+            _client()._make_request("GET", "/api/v1/x")
+        assert "demo.lightdash.cloud" in str(ei.value)
+        assert "instance_url" in str(ei.value)
+
+    def test_timeout_is_wrapped(self, monkeypatch):
+        def boom(*args, **kwargs):
+            raise httpx.ConnectTimeout("timed out")
+        monkeypatch.setattr(httpx.Client, "request", boom)
+
+        with pytest.raises(LightdashConnectionError, match="timed out"):
+            _client()._make_request("GET", "/api/v1/x")
+
+    def test_connection_error_subclasses_lightdash_error(self, monkeypatch):
+        """Existing `except LightdashError` handlers keep working."""
+        def boom(*args, **kwargs):
+            raise httpx.ConnectError("x")
+        monkeypatch.setattr(httpx.Client, "request", boom)
+
+        with pytest.raises(LightdashError):
+            _client()._make_request("GET", "/api/v1/x")
+
+    def test_original_error_is_chained(self, monkeypatch):
+        """The underlying httpx error is preserved as the cause for debugging."""
+        original = httpx.ConnectError("boom")
+        def boom(*args, **kwargs):
+            raise original
+        monkeypatch.setattr(httpx.Client, "request", boom)
+
+        with pytest.raises(LightdashConnectionError) as ei:
+            _client()._make_request("GET", "/api/v1/x")
+        assert ei.value.__cause__ is original
+
+
+class TestAuthErrors:
+    @pytest.mark.parametrize("status", [401, 403])
+    def test_auth_failure_raises_auth_error(self, monkeypatch, status):
+        monkeypatch.setattr(
+            httpx.Client, "request", lambda *a, **k: _response(status, text="unauthorized")
+        )
+        with pytest.raises(LightdashAuthError, match="Authentication failed") as ei:
+            _client()._make_request("GET", "/api/v1/x")
+        assert ei.value.status_code == status
+        assert "access_token" in str(ei.value)
+
+
+class TestExistingBehaviourPreserved:
+    """The structured-error and success paths are unchanged by this fix."""
+
+    def test_api_error_in_ok_response_is_surfaced(self, monkeypatch):
+        body = {"status": "error", "error": {"message": "Bad query", "name": "QueryError", "statusCode": 400}}
+        monkeypatch.setattr(httpx.Client, "request", lambda *a, **k: _response(200, json_body=body))
+        with pytest.raises(LightdashError, match="Bad query") as ei:
+            _client()._make_request("GET", "/api/v1/x")
+        assert not isinstance(ei.value, LightdashAuthError)
+
+    def test_ok_response_returns_results(self, monkeypatch):
+        body = {"status": "ok", "results": [{"a": 1}]}
+        monkeypatch.setattr(httpx.Client, "request", lambda *a, **k: _response(200, json_body=body))
+        assert _client()._make_request("GET", "/api/v1/x") == [{"a": 1}]


### PR DESCRIPTION
Closes #1

## Problem

A misconfigured client surfaced a raw, Lightdash-agnostic error that gave no hint at the cause:

```python
client = Client(instance_url="https://app.lightdash.com", access_token="xxxx", project_uuid="xxxx")
client.list_models()
# httpx.ConnectError: [Errno 8] nodename nor servname provided, or not known
```

## Change (intentionally minimal)

A nested `try` around just the request translates the two reported failure modes into clear, **catchable** exceptions. **The existing `raise_for_status` + structured-error handling is left completely untouched** (unchanged context in the diff):

| Failure | Exception | Message |
|---|---|---|
| DNS / refused connection / timeout | `LightdashConnectionError` | names `instance_url` + likely cause |
| HTTP 401 / 403 | `LightdashAuthError` | points at the `access_token` |

Both subclass `LightdashError`, so existing `except LightdashError` handlers keep working, and the original `httpx` error is chained as `__cause__`.

Production diff is **+61/−9** across 3 files; `client.py` is +37/−9, all additive around the request — no change to the success path or the existing API-error path.

> _Scope note:_ an earlier revision also reworked the 4xx/5xx path to surface the API's message on HTTP errors. That changed existing behaviour, so it was cut from this PR to keep it small; it can be a separate change later if wanted.

## Verified live (the issue's two exact cases)

```
CONNECT -> LightdashConnectionError (0): Could not connect to Lightdash at
           https://this-host-does-not-exist.invalid. Check that instance_url is correct...
AUTH    -> LightdashAuthError (401): Authentication failed (HTTP 401) for
           https://analytics.lightdash.cloud. Check that your access_token is valid...
```

## Tests

`tests/test_client_errors.py` (8): connect-error wrapping, timeout wrapping, `LightdashError` subclassing, cause-chaining, 401/403 → auth error, plus two guard tests that the **existing** structured-error and success paths are unchanged. Full unit suite green (131 passed).
