### PR TITLE
ci: automate releases on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Unit tests (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Floor and a current version; bump as supported range changes.
+        python-version: ["3.9", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package + dev deps
+        run: |
+          uv venv
+          uv pip install -e ".[dev]"
+
+      - name: Run unit tests
+        # test_acceptance.py and test_query.py require a live Lightdash
+        # instance + credentials, so they are excluded from CI.
+        run: |
+          uv run pytest tests/ \
+            --ignore=tests/test_acceptance.py \
+            --ignore=tests/test_query.py \
+            -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install package + dev deps
-        run: |
-          uv venv
-          uv pip install -e ".[dev]"
+        # setup-uv already created .venv and set VIRTUAL_ENV.
+        run: uv pip install -e ".[dev]"
 
       - name: Run unit tests
         # test_acceptance.py and test_query.py require a live Lightdash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+name: Release
+
+# Publish on merge to main. python-semantic-release inspects the Conventional
+# Commit messages since the last "v*" tag, decides the next version (or that no
+# release is warranted), bumps pyproject.toml, tags, creates a GitHub Release,
+# and we then upload the built artifacts to PyPI.
+#
+# The version-bump commit it pushes back to main contains "[skip ci]" so this
+# workflow does not retrigger itself.
+on:
+  push:
+    branches: [main]
+
+# Never run two releases concurrently.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+      - name: Install package + dev deps
+        run: |
+          uv venv
+          uv pip install -e ".[dev]"
+      - name: Run unit tests
+        run: |
+          uv run pytest tests/ \
+            --ignore=tests/test_acceptance.py \
+            --ignore=tests/test_query.py \
+            -q
+
+  release:
+    name: Semantic Release
+    runs-on: ubuntu-latest
+    needs: test
+    # Guard against forks: only the canonical repo should publish.
+    if: github.repository == 'lightdash/python-sdk'
+    permissions:
+      contents: write   # push the version bump/tag and create the GitHub Release
+      id-token: write   # PyPI Trusted Publishing (OIDC)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # semantic-release needs full history + tags
+
+      - name: Python Semantic Release
+        id: release
+        uses: python-semantic-release/python-semantic-release@v9
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to PyPI
+        if: steps.release.outputs.released == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Upload artifacts to the GitHub Release
+        if: steps.release.outputs.released == 'true'
+        uses: python-semantic-release/publish-action@v9
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.release.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,8 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install package + dev deps
-        run: |
-          uv venv
-          uv pip install -e ".[dev]"
+        # setup-uv already created .venv and set VIRTUAL_ENV.
+        run: uv pip install -e ".[dev]"
       - name: Run unit tests
         run: |
           uv run pytest tests/ \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,24 @@ include = ["lightdash*"]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 log_cli_level = "DEBUG"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+# Releases are automated by GitHub Actions (.github/workflows/release.yml).
+# python-semantic-release computes the next version from Conventional Commit
+# messages (feat: -> minor, fix: -> patch, BREAKING CHANGE -> major) since the
+# last "v*" tag, bumps the version below, tags, creates a GitHub Release, and
+# publishes to PyPI. Do not bump `version` by hand.
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+build_command = "pip install build && python -m build"
+commit_message = "chore(release): v{version} [skip ci]"
+tag_format = "v{version}"
+
+[tool.semantic_release.branches.main]
+match = "main"
+
+[tool.semantic_release.changelog]
+exclude_commit_patterns = ['''chore\(release\):.*''']


### PR DESCRIPTION
## What

Replaces the manual \`just publish\` flow with GitHub Actions so releases happen automatically on merge to main. Jake (and anyone else) no longer needs to know the release dance.

### Workflows
- **\`ci.yml\`** — runs the unit test suite on every PR and push to main (Python 3.9 + 3.12). Excludes \`test_acceptance.py\` and \`test_query.py\`, which require a live Lightdash instance + credentials.
- **\`release.yml\`** — on merge to main: runs tests, then [python-semantic-release](https://python-semantic-release.readthedocs.io/) computes the next version from Conventional Commit messages (\`feat:\` → minor, \`fix:\` → patch, \`BREAKING CHANGE\` → major), bumps \`pyproject.toml\`, tags, creates a GitHub Release, and publishes to PyPI via **Trusted Publishing** (OIDC — no stored tokens).

### Other
- Added an explicit \`[build-system]\` table (setuptools) — it was missing entirely.
- Added \`[tool.semantic_release]\` config; versions are anchored by a baseline \`v1.0.1\` tag (pushed) matching the current PyPI release.

## Why now

main currently declares \`version = "1.0.1"\` but PyPI already has 1.0.1 — and there are **8 unreleased PRs** sitting behind that already-used version number (row-cap fix, SQL compile, Bearer auth, etc.). Manual releases had drifted. Automation fixes this.

## ⚠️ Required before merge

PyPI **Trusted Publishing** must be configured once, or the publish step will fail:
- pypi.org → project \`lightdash\` → Settings → Publishing → Add a GitHub publisher
- Owner \`lightdash\`, repo \`python-sdk\`, workflow \`release.yml\`, environment blank

## What happens on merge

semantic-release will compute **1.1.0** (the 8 unreleased PRs include \`feat:\` commits) and publish it to PyPI automatically.